### PR TITLE
Support both explicit kubeconfigs and file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support both explicit kubeconfigs and file paths.
 
-### Changed
+### Fixed
 
-- Reduce interval when waiting for apps now app-operator has a status webhook.
+- Optimize apps wait interval as app-operator has a status webhook.
 
 ## [0.4.0] - 2020-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support both explicit kubeconfigs and file paths.
+
+### Changed
+
+- Reduce interval when waiting for apps now app-operator has a status webhook.
+
 ## [0.4.0] - 2020-10-29
 
 ### Changed

--- a/apptest.go
+++ b/apptest.go
@@ -32,6 +32,7 @@ const (
 
 // Config represents the configuration used to setup the apps.
 type Config struct {
+	KubeConfig     string
 	KubeConfigPath string
 
 	Logger micrologger.Logger
@@ -48,8 +49,11 @@ type AppSetup struct {
 func New(config Config) (*AppSetup, error) {
 	var err error
 
-	if config.KubeConfigPath == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.KubeConfig must not be empty", config)
+	if config.KubeConfig == "" && config.KubeConfigPath == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.KubeConfig and %T.KubeConfigPath must not be empty at the same time", config, config)
+	}
+	if config.KubeConfig != "" && config.KubeConfigPath != "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.KubeConfig and %T.KubeConfigPath must not be set at the same time", config, config)
 	}
 
 	if config.Logger == nil {
@@ -58,9 +62,20 @@ func New(config Config) (*AppSetup, error) {
 
 	var restConfig *rest.Config
 	{
-		restConfig, err = clientcmd.BuildConfigFromFlags("", config.KubeConfigPath)
-		if err != nil {
-			return nil, microerror.Mask(err)
+		if config.KubeConfig != "" {
+			bytes := []byte(config.KubeConfig)
+			restConfig, err = clientcmd.RESTConfigFromKubeConfig(bytes)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		} else if config.KubeConfigPath != "" {
+			restConfig, err = clientcmd.BuildConfigFromFlags("", config.KubeConfigPath)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		} else {
+			// Shouldn't happen but returning error just in case.
+			return nil, microerror.Maskf(invalidConfigError, "%T.KubeConfig and %T.KubeConfigPath must not be empty at the same time", config, config)
 		}
 	}
 

--- a/apptest.go
+++ b/apptest.go
@@ -321,7 +321,7 @@ func (a *AppSetup) waitForDeployedApp(ctx context.Context, appName string) error
 		a.logger.Log("level", "debug", "message", fmt.Sprintf("failed to get app CR status '%s': retrying in %s", deployedStatus, t), "stack", fmt.Sprintf("%v", err))
 	}
 
-	b := backoff.NewConstant(20*time.Minute, 30*time.Second)
+	b := backoff.NewConstant(20*time.Minute, 10*time.Second)
 	err = backoff.RetryNotify(o, b, n)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Using an explicit kubeconfig works well with `kind get kubeconfig` but other times we need to pass a file path.

I think it makes sense to support both and probably in apptestctl too which I'll do as a later change.

## Checklist

- [x] Update changelog in CHANGELOG.md.
