### PR TITLE
A custom 'Scheme' can be passed to configure the controller-runtime client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Expose method `EnsureCRDs` to register CRDs in the k8s API.
+- A custom `Scheme` can be passed to configure the controller-runtime client.
 
 ## [0.4.1] - 2020-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expose method `EnsureCRDs` to register CRDs in the k8s API.
 - A custom `Scheme` can be passed to configure the controller-runtime client.
+- Add getter method that returns the controller-runtime client.
 
 ## [0.4.1] - 2020-10-30
 

--- a/apptest.go
+++ b/apptest.go
@@ -177,6 +177,11 @@ func (a *AppSetup) K8sClient() kubernetes.Interface {
 	return a.k8sClient
 }
 
+// CtrlClient returns a controller-runtime client for use in automated tests.
+func (a *AppSetup) CtrlClient() client.Client {
+	return a.ctrlClient
+}
+
 func (a *AppSetup) createAppCatalogs(ctx context.Context, apps []App) error {
 	var err error
 


### PR DESCRIPTION
Sometimes when writing a test we'd like to have a controller client to interact with the k8s cluster (for instance, to list some CRs), and the client needs to be configured with the right types. The library can't be configured it to be ready for all cases, so we allow the client to pass a custom `scheme` with the desired types.

I also added a function that returns the controller-runtime client.

## Checklist

- [X] Update changelog in CHANGELOG.md.
