### PR TITLE
Generate catalog URL for Giant Swarm catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose method `EnsureCRDs` to register CRDs in the k8s API.
 - A custom `Scheme` can be passed to configure the controller-runtime client.
 - Add getter method that returns the controller-runtime client.
+- Generate catalog URLs for known catalogs.
 
 ## [0.4.1] - 2020-10-30
 

--- a/apptest.go
+++ b/apptest.go
@@ -3,6 +3,8 @@ package apptest
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path"
 	"time"
 
 	v1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
@@ -26,6 +28,7 @@ import (
 )
 
 const (
+	catalogBaseURL     = "https://giantswarm.github.io/"
 	deployedStatus     = "deployed"
 	namespace          = "giantswarm"
 	uniqueAppCRVersion = "0.0.0"
@@ -389,7 +392,13 @@ func getCatalogURL(app App) (string, error) {
 
 	for _, catalog := range giantSwarmCatalogs {
 		if app.CatalogName == catalog {
-			return fmt.Sprintf("https://giantswarm.github.io/%s/", app.CatalogName), nil
+			u, err := url.Parse(catalogBaseURL)
+			if err != nil {
+				return "", microerror.Mask(err)
+			}
+			u.Path = path.Join(u.Path, app.CatalogName)
+
+			return u.String(), nil
 		}
 	}
 

--- a/apptest.go
+++ b/apptest.go
@@ -413,10 +413,15 @@ func getCatalogURL(app App) (string, error) {
 // If a version is provided then this is returned. This is to allow app
 // dependencies to be installed.
 func getVersionForApp(ctx context.Context, app App) (version string, err error) {
+	catalogURL, err := getCatalogURL(app)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
 	if app.SHA == "" && app.Version != "" {
 		return app.Version, nil
 	} else if app.SHA != "" && app.Version == "" {
-		version, err := appcatalog.GetLatestVersion(ctx, app.CatalogURL, app.Name, "")
+		version, err := appcatalog.GetLatestVersion(ctx, catalogURL, app.Name, "")
 		if err != nil {
 			return "", microerror.Mask(err)
 		}

--- a/apptest.go
+++ b/apptest.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	catalogBaseURL     = "https://giantswarm.github.io/"
 	deployedStatus     = "deployed"
 	namespace          = "giantswarm"
 	uniqueAppCRVersion = "0.0.0"

--- a/apptest.go
+++ b/apptest.go
@@ -3,8 +3,6 @@ package apptest
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"path"
 	"time"
 
 	v1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
@@ -35,19 +33,20 @@ const (
 )
 
 var (
-	giantSwarmCatalogs = []string{
-		"control-plane-catalog",
-		"control-plane-test-catalog",
-		"default",
-		"default-test",
-		"giantswarm",
-		"giantswarm-test",
-		"giantswarm-operations-platform",
-		"giantswarm-operations-platform-test",
-		"giantswarm-playground",
-		"giantswarm-playground-test",
-		"releases",
-		"releases-test",
+	giantSwarmCatalogs = map[string]string{
+		"control-plane-catalog":               "https://giantswarm.github.io/control-plane-catalog/",
+		"control-plane-test-catalog":          "https://giantswarm.github.io/control-plane-test-catalog/",
+		"default":                             "https://giantswarm.github.io/default-catalog/",
+		"default-test":                        "https://giantswarm.github.io/default-test-catalog/",
+		"giantswarm":                          "https://giantswarm.github.io/giantswarm-catalog/",
+		"giantswarm-test":                     "https://giantswarm.github.io/giantswarm-test-catalog/",
+		"giantswarm-operations-platform":      "https://giantswarm.github.io/giantswarm-operations-platform-catalog/",
+		"giantswarm-operations-platform-test": "https://giantswarm.github.io/giantswarm-operations-platform-test-catalog/",
+		"giantswarm-playground":               "https://giantswarm.github.io/giantswarm-playground-catalog/",
+		"giantswarm-playground-test":          "https://giantswarm.github.io/giantswarm-playground-test-catalog/",
+		"helm-stable":                         "https://charts.helm.sh/stable/packages/",
+		"releases":                            "https://giantswarm.github.io/releases-catalog/",
+		"releases-test":                       "https://giantswarm.github.io/releases-test-catalog/",
 	}
 )
 
@@ -390,19 +389,12 @@ func getCatalogURL(app App) (string, error) {
 		return app.CatalogURL, nil
 	}
 
-	for _, catalog := range giantSwarmCatalogs {
-		if app.CatalogName == catalog {
-			u, err := url.Parse(catalogBaseURL)
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
-			u.Path = path.Join(u.Path, app.CatalogName)
-
-			return u.String(), nil
-		}
+	catalogURL, exists := giantSwarmCatalogs[app.CatalogName]
+	if !exists {
+		return "", microerror.Maskf(invalidConfigError, "catalog %#q not found and no URL provided", app.CatalogName)
 	}
 
-	return "", microerror.Maskf(invalidConfigError, "catalog %#q not found and no URL provided", app.CatalogName)
+	return catalogURL, nil
 }
 
 // getVersionForApp checks whether a commit SHA or a version was provided.


### PR DESCRIPTION
Extends the library to generate the catalog URL if it is one of our catalogs. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
