### PR TITLE
Don't fail when ensuring a CRD that's already present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't fail when ensuring a CRD that's already present.
+
 ## [0.5.0] - 2020-11-06
 
 ### Fixed

--- a/apptest.go
+++ b/apptest.go
@@ -182,7 +182,9 @@ func (a *AppSetup) EnsureCRDs(ctx context.Context, crds []*apiextensionsv1.Custo
 	var err error
 	for _, crd := range crds {
 		err = a.ctrlClient.Create(ctx, crd)
-		if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// It's ok.
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 	}


### PR DESCRIPTION
I wanted to re-run my tests locally, but `apptest` fails due to the CRD being already present

```customresourcedefinitions.apiextensions.k8s.io "azureclusterconfigs.core.giantswarm.io" already exists```

With this change, we don't fail in that case.

## Checklist

- [X] Update changelog in CHANGELOG.md.
