### PR TITLE
Install specified app version instead of latest when passing the 'SHA' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Install specified app version instead of latest when passing the `SHA` parameter.
+
 ## [0.6.0] - 2020-11-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Install specified app version instead of latest when passing the `SHA` parameter.
 
+### Changed
+
+- Updated `appcatalog` library.
+
 ## [0.6.0] - 2020-11-12
 
 ### Changed

--- a/apptest.go
+++ b/apptest.go
@@ -414,7 +414,7 @@ func getVersionForApp(ctx context.Context, app App) (version string, err error) 
 	if app.SHA == "" && app.Version != "" {
 		return app.Version, nil
 	} else if app.SHA != "" && app.Version == "" {
-		version, err := appcatalog.GetLatestVersion(ctx, catalogURL, app.Name, "")
+		version, err := appcatalog.GetLatestVersion(ctx, catalogURL, app.Name, app.SHA)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/giantswarm/apiextensions/v3 v3.7.0
-	github.com/giantswarm/appcatalog v0.2.7
+	github.com/giantswarm/appcatalog v0.3.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/micrologger v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions/v3 v3.7.0 h1:KUAjZn3OMMkmTWvgAfAPTLdrNbFY2zukMntdeLhMGY4=
 github.com/giantswarm/apiextensions/v3 v3.7.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
-github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
+github.com/giantswarm/appcatalog v0.3.0 h1:enpcVE46WGUbLHa7D2BpEtjd9xXH5/DmcVmHLc7Nt38=
+github.com/giantswarm/appcatalog v0.3.0/go.mod h1:cjOuCqi8gWudFY0ogbp4ukSV4Vff6kfInR9VdrX+7yI=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/cluster-api v0.3.10-gs/go.mod h1:878STePVJcBNDYFY2eCsLuHXWs6qiH3INFItEwdfWaE=


### PR DESCRIPTION
This looks like a bug to me, but I'm not sure if it was intentionally done.

## Checklist

- [X] Update changelog in CHANGELOG.md.
