### PR TITLE
Extend support for setting the app CR name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extend support for setting the app CR name.
+
 ## [0.10.1] - 2021-02-08
 
 ### Fixed

--- a/apptest.go
+++ b/apptest.go
@@ -662,7 +662,7 @@ func (a *AppSetup) waitForDeployedApp(ctx context.Context, testApp App) error {
 	o := func() error {
 		err = a.ctrlClient.Get(
 			ctx,
-			types.NamespacedName{Name: testApp.Name, Namespace: appCRNamespace},
+			types.NamespacedName{Name: appCRName, Namespace: appCRNamespace},
 			&app)
 		if err != nil {
 			return microerror.Mask(err)

--- a/apptest.go
+++ b/apptest.go
@@ -554,6 +554,13 @@ func (a *AppSetup) updateApp(ctx context.Context, desired App) error {
 	var err error
 	var currentApp v1alpha1.App
 
+	var appCRName string
+	if desired.AppCRName != "" {
+		appCRName = desired.AppCRName
+	} else {
+		appCRName = desired.Name
+	}
+
 	var appCRNamespace string
 	if desired.AppCRNamespace != "" {
 		appCRNamespace = desired.AppCRNamespace
@@ -561,17 +568,17 @@ func (a *AppSetup) updateApp(ctx context.Context, desired App) error {
 		appCRNamespace = defaultNamespace
 	}
 
-	a.logger.Debugf(ctx, "finding %#q app in namespace %#q", desired.Name, appCRNamespace)
+	a.logger.Debugf(ctx, "finding %#q app in namespace %#q", appCRName, appCRNamespace)
 
 	err = a.ctrlClient.Get(
 		ctx,
-		types.NamespacedName{Name: desired.Name, Namespace: appCRNamespace},
+		types.NamespacedName{Name: appCRName, Namespace: appCRNamespace},
 		&currentApp)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	a.logger.Debugf(ctx, "found %#q app in namespace %#q", desired.Name, appCRNamespace)
+	a.logger.Debugf(ctx, "found %#q app in namespace %#q", appCRName, appCRNamespace)
 
 	desiredApp := currentApp.DeepCopy()
 
@@ -632,6 +639,14 @@ func (a *AppSetup) waitForDeployedApps(ctx context.Context, apps []App) error {
 func (a *AppSetup) waitForDeployedApp(ctx context.Context, testApp App) error {
 	var err error
 
+	var appCRName string
+
+	if testApp.AppCRName != "" {
+		appCRName = testApp.AppCRName
+	} else {
+		appCRName = testApp.Name
+	}
+
 	var appCRNamespace string
 
 	if testApp.AppCRNamespace != "" {
@@ -640,7 +655,7 @@ func (a *AppSetup) waitForDeployedApp(ctx context.Context, testApp App) error {
 		appCRNamespace = defaultNamespace
 	}
 
-	a.logger.Debugf(ctx, "ensuring '%s/%s' app CR is %#q", appCRNamespace, testApp.Name, deployedStatus)
+	a.logger.Debugf(ctx, "ensuring '%s/%s' app CR is %#q", appCRNamespace, appCRName, deployedStatus)
 
 	var app v1alpha1.App
 


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/apptest/pull/63. I missed some places when making the app CR name configurable.


## Checklist

- [x] Update changelog in CHANGELOG.md.
