### PR TITLE
Add .RESTConfig() for use in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `RESTConfig()` for use in integration tests.
+
 ## [0.11.0] - 2021-06-16
 
 ### Added

--- a/apptest.go
+++ b/apptest.go
@@ -66,6 +66,7 @@ type AppSetup struct {
 	ctrlClient client.Client
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
+	restConfig *rest.Config
 }
 
 // New creates a new configured app setup library.
@@ -152,6 +153,7 @@ func New(config Config) (*AppSetup, error) {
 		ctrlClient: ctrlClient,
 		k8sClient:  k8sClient,
 		logger:     config.Logger,
+		restConfig: restConfig,
 	}
 
 	return a, nil
@@ -252,6 +254,11 @@ func (a *AppSetup) K8sClient() kubernetes.Interface {
 // CtrlClient returns a controller-runtime client for use in automated tests.
 func (a *AppSetup) CtrlClient() client.Client {
 	return a.ctrlClient
+}
+
+// RESTConfig returns a Kubernetes REST config for use in automated tests.
+func (a *AppSetup) RESTConfig() *rest.Config {
+	return a.restConfig
 }
 
 func (a *AppSetup) CleanUp(ctx context.Context, apps []App) error {

--- a/spec.go
+++ b/spec.go
@@ -6,6 +6,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,6 +30,9 @@ type Interface interface {
 
 	// CleanUp removes created resources while installing apps.
 	CleanUp(ctx context.Context, apps []App) error
+
+	// RESTConfig returns a Kubernetes REST config for use in automated tests.
+	RESTConfig() *rest.Config
 }
 
 type App struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18384

I'd like to drop k8sclient from the app-exporter tests but it needs a REST client for k8sportforward.

We already need to create the REST client. This just makes it available in tests.

## Checklist

- [x] Update changelog in CHANGELOG.md.
