### PR TITLE
Reduce log level when waiting for statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce log level when waiting for statuses from error to debug.
+
 ## [1.0.0] - 2021-11-29
 
 ### Changed

--- a/apptest.go
+++ b/apptest.go
@@ -603,7 +603,7 @@ func (a *AppSetup) ensureCRD(ctx context.Context, crd *apiextensionsv1.CustomRes
 	}
 
 	n := func(err error, t time.Duration) {
-		a.logger.Errorf(ctx, err, "failed to get CRD '%s': retrying in %s", crd.Name, t)
+		a.logger.Debugf(ctx, "failed to get CRD '%s': retrying in %s", crd.Name, t)
 	}
 
 	b := backoff.NewExponential(1*time.Minute, 10*time.Second)
@@ -759,7 +759,7 @@ func (a *AppSetup) waitForDeployedApp(ctx context.Context, testApp App) error {
 	}
 
 	n := func(err error, t time.Duration) {
-		a.logger.Errorf(ctx, err, "failed to get app CR status '%s': retrying in %s", deployedStatus, t)
+		a.logger.Debugf(ctx, "failed to get app CR status '%s': retrying in %s", deployedStatus, t)
 	}
 
 	b := backoff.NewConstant(20*time.Minute, 10*time.Second)


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/apptestctl/pull/194

By default we now only show error logs but these wait errors are not true errors. Reducing their log level to debug.

## Checklist

- [x] Update changelog in CHANGELOG.md.
