### PR TITLE
fix: resolve charts and deployed versions published with an abbreviated SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `external-dns-app` and `kyverno-policies-dx`.
 - Migrate build system to ABS.
 
+### Fixed
+
+- Bump `appcatalog` to v1.0.2 so chart lookups resolve against charts published with an abbreviated
+  SHA. `InstallApps` passes `App.SHA` straight through to `appcatalog.GetLatestVersion`, and appcatalog
+  matched the index entry with `strings.HasSuffix(entry.Version, appVersion)`. That worked while
+  architect published charts as `<version>-<full 40 character SHA>`, but since the architect orb bump
+  to 9.x the published format is the gitsemver development version, whose trailing SHA is abbreviated
+  to seven characters. A full SHA can never match that by suffix, so callers passing `CIRCLE_SHA1`
+  failed with `no app ... in index.yaml with given appVersion` even though the chart was published
+  correctly. Callers passing `App.Version` were never affected. appcatalog v1.0.2 accepts both formats.
+
 ## [1.4.1] - 2024-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bump `appcatalog` to v1.0.2 so chart lookups resolve against charts published with an abbreviated
-  SHA. `InstallApps` passes `App.SHA` straight through to `appcatalog.GetLatestVersion`, and appcatalog
-  matched the index entry with `strings.HasSuffix(entry.Version, appVersion)`. That worked while
-  architect published charts as `<version>-<full 40 character SHA>`, but since the architect orb bump
-  to 9.x the published format is the gitsemver development version, whose trailing SHA is abbreviated
-  to seven characters. A full SHA can never match that by suffix, so callers passing `CIRCLE_SHA1`
-  failed with `no app ... in index.yaml with given appVersion` even though the chart was published
-  correctly. Callers passing `App.Version` were never affected. appcatalog v1.0.2 accepts both formats.
+- Wait for a deployed app using `appcatalog.MatchesVersion` instead of a plain suffix test, and bump
+  `appcatalog` to v1.1.0. Both the chart lookup and this wait assumed architect's old
+  `<version>-<full 40 character SHA>` format. Since architect orb 9.x the published format is the
+  gitsemver development version, e.g. `1.4.2-dev.my-branch.2026-08-19.15-42-45.hb1fae9f`, whose
+  trailing SHA is abbreviated to seven characters -- so `strings.HasSuffix(app.Status.Version,
+  testApp.SHA)` could never be true and `waitForDeployedApp` spun until the caller's test timed out:
+
+      waiting for version contains `b1fae9f6112917bc5d936661f533610b52d2d19f`,
+      current version `1.4.2-dev.bump-appcatalog-1-0-2.2026-08-19.15-42-45.hb1fae9f`
+
+  appcatalog v1.0.2 fixed the lookup half; v1.1.0 exports the same matcher so this half uses one shared
+  implementation rather than a second copy of the rule. Callers passing `App.Version` rather than
+  `App.SHA` were never affected and are unchanged.
 
 ## [1.4.1] - 2024-06-04
 

--- a/apptest.go
+++ b/apptest.go
@@ -3,7 +3,6 @@ package apptest
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -727,7 +726,11 @@ func (a *AppSetup) waitForDeployedApp(ctx context.Context, testApp App) error {
 		case notInstalledStatus, failedStatus:
 			return backoff.Permanent(microerror.Maskf(executionFailedError, "status %#q, reason: %s", app.Status.Release.Status, app.Status.Release.Reason))
 		case deployedStatus:
-			if testApp.SHA != "" && strings.HasSuffix(app.Status.Version, testApp.SHA) {
+			// appcatalog.MatchesVersion rather than a plain suffix test: architect orb 9.x
+			// publishes development versions whose trailing SHA is abbreviated to seven
+			// characters, e.g. "1.4.2-dev.my-branch.2026-08-19.15-42-45.hb1fae9f", so a full
+			// SHA can never be a suffix of the deployed version and this wait never returned.
+			if testApp.SHA != "" && appcatalog.MatchesVersion(app.Status.Version, testApp.SHA) {
 				return nil
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/app/v7 v7.1.0
-	github.com/giantswarm/appcatalog v1.0.1
+	github.com/giantswarm/appcatalog v1.0.2
 	github.com/giantswarm/backoff v1.0.1
 	github.com/giantswarm/k8smetadata v0.26.0
 	github.com/giantswarm/microerror v0.4.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/app/v7 v7.1.0
-	github.com/giantswarm/appcatalog v1.0.2
+	github.com/giantswarm/appcatalog v1.1.0
 	github.com/giantswarm/backoff v1.0.1
 	github.com/giantswarm/k8smetadata v0.26.0
 	github.com/giantswarm/microerror v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/giantswarm/app/v7 v7.1.0 h1:Az26fpOTe8YzYEWepBmfQSxP8zk1owXBj/jBTNUmy
 github.com/giantswarm/app/v7 v7.1.0/go.mod h1:vgv51aLIWIugQhIVaeP1f5qYxO+0tpnw4bXRFXzoDE8=
 github.com/giantswarm/appcatalog v1.0.2 h1:1k2iiQ60atiIP1TzKMpCxyK9mTMcX3Dk16NoenDK/VA=
 github.com/giantswarm/appcatalog v1.0.2/go.mod h1:22bcRghWPjOuZ60KY46DoOI85YinTEaCQROJVF1C+iQ=
+github.com/giantswarm/appcatalog v1.1.0 h1:/D2nFMXocEluPMgCcOQp/v9c40pckRx2+pbjyJnOf50=
+github.com/giantswarm/appcatalog v1.1.0/go.mod h1:IM8qGt89wynQM1nTRE8PG8n0SfZASvIlp65pN+lQJUk=
 github.com/giantswarm/backoff v1.0.1 h1:paqQhjUsibkf+wWFCHsk7VXAkcM1L3ssAe7V7i8twpM=
 github.com/giantswarm/backoff v1.0.1/go.mod h1:RGj8b06J3irMNFRoSiMnngS50K+QbpSvu77sW03bxqQ=
 github.com/giantswarm/k8smetadata v0.26.0 h1:2TLymlfjYLyioRRimbm0CxRzEr5lMivsuEiE32+JYxQ=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/app/v7 v7.1.0 h1:Az26fpOTe8YzYEWepBmfQSxP8zk1owXBj/jBTNUmyx8=
 github.com/giantswarm/app/v7 v7.1.0/go.mod h1:vgv51aLIWIugQhIVaeP1f5qYxO+0tpnw4bXRFXzoDE8=
-github.com/giantswarm/appcatalog v1.0.2 h1:1k2iiQ60atiIP1TzKMpCxyK9mTMcX3Dk16NoenDK/VA=
-github.com/giantswarm/appcatalog v1.0.2/go.mod h1:22bcRghWPjOuZ60KY46DoOI85YinTEaCQROJVF1C+iQ=
 github.com/giantswarm/appcatalog v1.1.0 h1:/D2nFMXocEluPMgCcOQp/v9c40pckRx2+pbjyJnOf50=
 github.com/giantswarm/appcatalog v1.1.0/go.mod h1:IM8qGt89wynQM1nTRE8PG8n0SfZASvIlp65pN+lQJUk=
 github.com/giantswarm/backoff v1.0.1 h1:paqQhjUsibkf+wWFCHsk7VXAkcM1L3ssAe7V7i8twpM=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/app/v7 v7.1.0 h1:Az26fpOTe8YzYEWepBmfQSxP8zk1owXBj/jBTNUmyx8=
 github.com/giantswarm/app/v7 v7.1.0/go.mod h1:vgv51aLIWIugQhIVaeP1f5qYxO+0tpnw4bXRFXzoDE8=
-github.com/giantswarm/appcatalog v1.0.1 h1:hUBN5CTGbfMYiO28XihSf7kUnnPguTLOBr9BAtqfKK4=
-github.com/giantswarm/appcatalog v1.0.1/go.mod h1:mL+OaULPRgdnf91Vws1pmyvqVxx16t89s4kDF/O/ps0=
+github.com/giantswarm/appcatalog v1.0.2 h1:1k2iiQ60atiIP1TzKMpCxyK9mTMcX3Dk16NoenDK/VA=
+github.com/giantswarm/appcatalog v1.0.2/go.mod h1:22bcRghWPjOuZ60KY46DoOI85YinTEaCQROJVF1C+iQ=
 github.com/giantswarm/backoff v1.0.1 h1:paqQhjUsibkf+wWFCHsk7VXAkcM1L3ssAe7V7i8twpM=
 github.com/giantswarm/backoff v1.0.1/go.mod h1:RGj8b06J3irMNFRoSiMnngS50K+QbpSvu77sW03bxqQ=
 github.com/giantswarm/k8smetadata v0.26.0 h1:2TLymlfjYLyioRRimbm0CxRzEr5lMivsuEiE32+JYxQ=


### PR DESCRIPTION
### Why

Two separate places in this stack assumed architect's old `<version>-<full 40 character SHA>` chart
format. Since the architect orb bump to 9.x, the published format is the gitsemver development
version, e.g. `1.4.2-dev.my-branch.2026-08-19.15-42-45.hb1fae9f`, whose trailing SHA is abbreviated to
**seven** characters.

1. **The chart lookup**, in `appcatalog` — fixed in
   [appcatalog#303](https://github.com/giantswarm/appcatalog/pull/303), released as v1.0.2.
2. **This repo's own wait loop**, `waitForDeployedApp`:

```go
if testApp.SHA != "" && strings.HasSuffix(app.Status.Version, testApp.SHA) {
```

A full SHA can never be a suffix of the new format, so the wait spun until the caller's test timed
out. From this PR's own failing run before the fix — note the app *did* deploy, and the lookup *did*
succeed:

```
waiting for version contains `b1fae9f6112917bc5d936661f533610b52d2d19f`,
current version `1.4.2-dev.bump-appcatalog-1-0-2.2026-08-19.15-42-45.hb1fae9f`
```

```
panic: test timed out after 20m0s
FAIL github.com/giantswarm/apptest/integration/test/basic  1200.021s
```

This is also what makes `app-operator`'s `workload-cluster-integration-test` hang, and why
`app-admission-controller` passed throughout — its local `"h" + sha[:7]` workaround happens to satisfy
both checks.

### What changed

- `appcatalog` → **v1.1.0**.
- `waitForDeployedApp` uses `appcatalog.MatchesVersion` instead of `strings.HasSuffix`.
  [appcatalog#306](https://github.com/giantswarm/appcatalog/pull/306) exported that matcher precisely
  so the rule lives in one place rather than being copied here.
- `strings` was only used at that one call site, so the import is dropped.

The `App.Version` branch is untouched — callers passing a plain chart version were never affected, and
`MatchesVersion` keeps that path byte-identical by only applying the abbreviated comparison when the
value looks like a git object name.

### Verification

`gofmt`, `go build ./...`, `go vet ./...` all clean. The real check is this PR's own
`basic-integration-test`, which failed on exactly this before the change.

### Follow-up

Once this is released, `app-operator#1590` bumps `apptest` and its fourth integration test should go
green — the appcatalog v1.0.2 bump already took it from 4 failures to 1. The `"h" + sha[:7]` workaround
in `app-admission-controller` can then be reverted in favour of the library fix; it stays correct
either way, so that is tidying rather than urgent.
