### PR TITLE
fix: trim trailing dot from helm.sh/chart label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Trim a trailing `.` as well as `-` from the `helm.sh/chart` label in the test chart. The label is
+  built as `printf "%s-%s" .Chart.Name .Chart.Version | trunc 63 | trimSuffix "-"`. Since architect
+  orb 9.x, `.Chart.Version` is the gitsemver development version, which `gitsemver` caps at 63
+  characters; prefixing `apptest-app-` pushes it past the 63-character label limit, so `trunc` now
+  cuts mid-version. `trimSuffix "-"` handles a cut landing on a dash but not on a dot, and a label
+  may not end in `.`, so the render was rejected outright:
+
+      Deployment.apps "apptest-app" is invalid: metadata.labels: Invalid value:
+      "apptest-app-1.4.2-dev.renovate-k8s-modules.2026-08-20.13-16-19.": a valid label must ...
+      start and end with an alphanumeric character
+
+  Which character the cut lands on is fixed by the length of the branch name, so this is
+  deterministic per branch rather than flaky -- `renovate/k8s-modules` always cuts on the dot before
+  the abbreviated SHA and always fails, while `renovate/architect-10.x` always cuts on a dash inside
+  the timestamp and always passes. `trimAll "-._"` covers every separator the version can end on.
+
 - Wait for a deployed app using `appcatalog.MatchesVersion` instead of a plain suffix test, and bump
   `appcatalog` to v1.1.0. Both the chart lookup and this wait assumed architect's old
   `<version>-<full 40 character SHA>` format. Since architect orb 9.x the published format is the

--- a/helm/apptest-app/templates/_helpers.tpl
+++ b/helm/apptest-app/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimAll "-._" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Why

`basic-integration-test` fails on #498 (`renovate/k8s-modules`) with an invalid Kubernetes label. It
is not flaky and not related to the k8s-module bump — the same failure reproduced across a rebase
with only the timestamp changing ([6563](https://circleci.com/gh/giantswarm/apptest/6563) at
`13-16-19`, [6712](https://circleci.com/gh/giantswarm/apptest/6712) at `14-03-03`):

```
Deployment.apps "apptest-app" is invalid: metadata.labels: Invalid value:
"apptest-app-1.4.2-dev.renovate-k8s-modules.2026-08-20.14-03-03.": a valid label must be an
empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end
with an alphanumeric character
```

The `helm.sh/chart` label is built in `_helpers.tpl`:

```
printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-"
```

Since architect orb 9.x, `.Chart.Version` is the gitsemver development version. `gitsemver` caps
that at 63 characters itself — visible in the builds, where it elides the middle of a long branch
name to fit (note the `--` in `renovate-gi--gr-logr-1-x`). Prefixing `apptest-app-` adds 12
characters and pushes it past the 63-character label limit, so `trunc 63` cuts mid-version.
`trimSuffix "-"` covers a cut landing on a dash but not on a dot, and a label may not end in `.`.

**Which character the cut lands on is fixed by the length of the branch name**, so each branch
either always fails or always passes — this is deterministic, not intermittent. From the real
version strings:

| build | branch | version len | char at cut | after `trimSuffix "-"` | result |
|---|---|---|---|---|---|
| 6712 | `renovate/k8s-modules` | 59 | `.` | `.` | **always fails** |
| 6580 | `renovate/architect-10.x` | 62 | `-` | `7` | always passes |
| 6583 | `renovate/…app-v7-8.x` | 62 | `-` | `8` | always passes |
| 6559 | `renovate/…logr-1.x` | 63 | `6` | `6` | always passes |

That is why only this one PR is red while the others went green after #503, and why re-running it
was never going to help.

### What changed

`trimSuffix "-"` → `trimAll "-._"`, so every separator the truncated version can end on is trimmed.
One line, plus a CHANGELOG entry.

### Verification

Reproduced locally with `helm template`, which rendered
`"apptest-app-1.4.2-dev.renovate-k8s-modules.2026-08-20.14-03-03."` — byte-identical to the string
in build 6712 — and renders without the trailing dot after the change.

Then two checks:

1. **Correctness.** A script renders the chart at 9 versions (the four real ones above plus a release
   tag, a one-character branch, and lengths either side of the failing boundary) and validates every
   label in every rendered document against the Kubernetes label regex and the 63-character limit.
   All pass with the fix. Reverting the fix makes it flag exactly the `helm.sh/chart` value above,
   so the check is not vacuous — an earlier version of it was, and reported a false pass until I
   verified it against the known-bad input.
2. **No churn.** Rendering the four real versions against the parent commit and against this one,
   the *only* difference is the failing case losing its trailing dot. The three passing versions and
   a plain `1.4.2` release version are byte-identical, so this cannot disturb a branch that works
   today.

`helm lint` passes.

### Note

Out of scope, pre-existing, and unaffected by this change: a version carrying `+build` metadata
renders invalid `application.giantswarm.io/branch` and `/commit` labels, because lines 21–22 do not
strip `+` the way line 13 does. It fails identically with and without this fix, and `gitsemver` does
not emit `+build` metadata, so it is synthetic rather than something CI hits.

### Landing

This needs to merge to `main` first; #498 then goes green on a rebase — the same shape as #503 and
the dependency PRs.
