### PR TITLE
fix(deps): update module github.com/giantswarm/app/v7 to v8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/app/v7 v7.1.0
+	github.com/giantswarm/app/v8 v8.1.1
 	github.com/giantswarm/appcatalog v1.1.0
 	github.com/giantswarm/backoff v1.0.1
 	github.com/giantswarm/k8smetadata v0.26.0
@@ -46,7 +46,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.28.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-github/v69 v69.2.0 // indirect
+	github.com/google/go-github/v82 v82.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/app/v7 v7.1.0 h1:Az26fpOTe8YzYEWepBmfQSxP8zk1owXBj/jBTNUmyx8=
-github.com/giantswarm/app/v7 v7.1.0/go.mod h1:vgv51aLIWIugQhIVaeP1f5qYxO+0tpnw4bXRFXzoDE8=
+github.com/giantswarm/app/v8 v8.1.1 h1:kS9Ma++OBVyODEzYiGA6JcYNOCxuAxu17VpYneIzyIA=
+github.com/giantswarm/app/v8 v8.1.1/go.mod h1:TUwvutQSqcs43FUsoSHlcIS87aqhYyJ2uunbf5Hbb1E=
 github.com/giantswarm/appcatalog v1.1.0 h1:/D2nFMXocEluPMgCcOQp/v9c40pckRx2+pbjyJnOf50=
 github.com/giantswarm/appcatalog v1.1.0/go.mod h1:IM8qGt89wynQM1nTRE8PG8n0SfZASvIlp65pN+lQJUk=
 github.com/giantswarm/backoff v1.0.1 h1:paqQhjUsibkf+wWFCHsk7VXAkcM1L3ssAe7V7i8twpM=
@@ -85,8 +85,8 @@ github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7O
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
-github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
+github.com/google/go-github/v82 v82.0.0 h1:OH09ESON2QwKCUVMYmMcVu1IFKFoaZHwqYaUtr/MVfk=
+github.com/google/go-github/v82 v82.0.0/go.mod h1:hQ6Xo0VKfL8RZ7z1hSfB4fvISg0QqHOqe9BP0qo+WvM=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/integration/test/ensurecrds/ensure_crds_test.go
+++ b/integration/test/ensurecrds/ensure_crds_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/giantswarm/app/v7/pkg/crd"
+	"github.com/giantswarm/app/v8/pkg/crd"
 	monitoringv1alpha1 "github.com/giantswarm/silence-operator/api/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Supersedes #506, which cannot pass CI as raised.

### Why #506 fails

Renovate updated the go.mod require path to `github.com/giantswarm/app/v8 v8.1.1` — correct for a Go
major bump — but stopped there. It did not update `go.sum`, and it did not rewrite the one import
still on the old path. The `go-test` job's *Check if go.mod and go.sum are clean* step runs
`go mod tidy`, which resolves that import back to v7 and reverts the bump
([build 6801](https://circleci.com/gh/giantswarm/apptest/6801)):

```
go: finding module for package github.com/giantswarm/app/v7/pkg/crd
go: found github.com/giantswarm/app/v7/pkg/crd in github.com/giantswarm/app/v7 v7.1.0
-	github.com/giantswarm/app/v8 v8.1.1
+	github.com/giantswarm/app/v7 v7.1.0
```

The resulting non-empty diff fails the step. `go mod tidy` reads imports from all files regardless of
build constraints, which is why a single `k8srequired`-tagged test file drives the whole resolution.

This is also what happened to #490, on this same branch: it merged carrying only the transitive
bumps (`go-querystring` v1.1.0 -> v1.2.0, `oauth2` v0.34.0 -> v0.35.0) with the app dependency
untouched, which is why `main` still reads `github.com/giantswarm/app/v7 v7.1.0` today despite that
PR's title. Renovate then re-raised the update as #506.

### What changed

- `integration/test/ensurecrds/ensure_crds_test.go`: import `github.com/giantswarm/app/v8/pkg/crd`.
- `go.mod` / `go.sum`: `app/v8 v8.1.1` and the transitive `go-github` v69 -> v82, via `go mod tidy`.

The only API surface used from that module is `crd.Config`, `crd.NewCRDGetter` and `crd.CRDGetter`,
which v8 leaves unchanged. v8.0.0's breaking change was to the `app.Validator` interface
(`projectName` string replaced by `isAdmissionController` bool, `enableManagedByLabel` removed), and
this repo does not use it.

No CHANGELOG entry: the validate-changelog workflow is path-filtered to `CHANGELOG.md`, and this
does not change apptest's own public API.

### Verification

`go mod tidy` is now a no-op — the exact check that failed on #506. Also clean: `go build ./...`,
`go vet -tags k8srequired ./...` (the tag that actually compiles the changed file), `gofmt`,
`go mod verify`. No `github.com/giantswarm/app/v7` reference remains anywhere, `go.sum` included.
